### PR TITLE
Add LICENSE (CC-BY-IGO-4.0) and CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,14 @@
+cff-version: 1.2.0
+message: If you use this work, please cite it as below.
+title: OBIS Thermal Dataset
+type: dataset
+abstract: Sea temperature matched to occurrence records
+url: https://github.com/iobis/obistherm
+license: CC-BY-IGO-4.0
+authors:
+  - family-names: silasprincipe
+    orcid: "https://orcid.org/0000-0002-8059-6304"
+  - name: Intergovernmental Oceanographic Commission of UNESCO
+    alias: IOC-UNESCO
+    website: "https://obis.org"
+date-released: 2025-05-02

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,20 @@
+Creative Commons Attribution 4.0 International IGO License (CC-BY-IGO-4.0)
+
+Copyright (c) 2026 Intergovernmental Oceanographic Commission of UNESCO
+
+This work is licensed under the Creative Commons Attribution 4.0
+International IGO License.
+
+To view a copy of this license, visit:
+https://creativecommons.org/licenses/by/4.0/igo/
+
+You are free to:
+  - Share: copy and redistribute the material in any medium or format
+  - Adapt: remix, transform, and build upon the material for any purpose
+
+Under the following terms:
+  - Attribution: You must give appropriate credit, provide a link to the
+    license, and indicate if changes were made.
+
+No additional restrictions: You may not apply legal terms or technological
+measures that legally restrict others from doing anything the license permits.


### PR DESCRIPTION
Adds LICENSE (CC-BY-IGO-4.0) and CITATION.cff to this repository.

**LICENSE**: CC-BY-IGO-4.0
**Copyright holder**: Intergovernmental Oceanographic Commission of UNESCO

**CITATION.cff**: Generated from GitHub contributor data. Please review author names — some may be GitHub usernames only.

Part of the OBIS Zenodo publishing initiative.